### PR TITLE
Add Shared TCP Channel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>pt.unl.fct.di.novasys</groupId>
     <artifactId>network-layer</artifactId>
-    <version>2.0.42</version>
+    <version>2.0.43</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.89.Final</version>
+            <version>4.1.96.Final</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.13.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/pt/unl/fct/di/novasys/channel/IChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/IChannel.java
@@ -8,5 +8,5 @@ public interface IChannel<T> {
 
     void closeConnection(Host peer, int connection);
 
-    void openConnection(Host peer);
+    void openConnection(Host peer, int connection);
 }

--- a/src/main/java/pt/unl/fct/di/novasys/channel/accrual/AccrualChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/accrual/AccrualChannel.java
@@ -134,7 +134,7 @@ public class AccrualChannel<T> extends SingleThreadedBiChannel<T, AccrualMessage
     }
 
     @Override
-    protected void onOpenConnection(Host peer) {
+    protected void onOpenConnection(Host peer, int connection) {
         OutConnectionState<AccrualMessage<T>> conState = outConnections.get(peer);
         if (conState == null) {
             logger.debug("onOpenConnection creating connection to: " + peer);

--- a/src/main/java/pt/unl/fct/di/novasys/channel/ackos/AckosChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/ackos/AckosChannel.java
@@ -191,7 +191,7 @@ public class AckosChannel<T> extends SingleThreadedBiChannel<T, AckosMessage<T>>
     }
 
     @Override
-    protected void onOpenConnection(Host peer) {
+    protected void onOpenConnection(Host peer, int connection) {
         throw new NotImplementedException("Pls fix me");
     }
 

--- a/src/main/java/pt/unl/fct/di/novasys/channel/base/SingleThreadedChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/base/SingleThreadedChannel.java
@@ -46,10 +46,10 @@ public abstract class SingleThreadedChannel<T, Y> implements IChannel<T>, Messag
     protected abstract void onDeliverMessage(Y msg, Connection<Y> conn);
 
     @Override
-    public void openConnection(Host peer) {
-        loop.execute(() -> onOpenConnection(peer));
+    public void openConnection(Host peer, int connection) {
+        loop.execute(() -> onOpenConnection(peer, connection));
     }
 
-    protected abstract void onOpenConnection(Host peer);
+    protected abstract void onOpenConnection(Host peer, int connection);
 
 }

--- a/src/main/java/pt/unl/fct/di/novasys/channel/simpleclientserver/SimpleClientChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/simpleclientserver/SimpleClientChannel.java
@@ -88,7 +88,7 @@ public class SimpleClientChannel<T> extends SingleThreadedClientChannel<T, T> {
     }
 
     @Override
-    protected void onOpenConnection(Host peer) {
+    protected void onOpenConnection(Host peer, int conn) {
         connection = network.createConnection(serverAddress, SIMPLE_CLIENT_ATTRIBUTES, this);
         state = State.CONNECTING;
     }

--- a/src/main/java/pt/unl/fct/di/novasys/channel/simpleclientserver/SimpleServerChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/simpleclientserver/SimpleServerChannel.java
@@ -133,7 +133,7 @@ public class SimpleServerChannel<T> extends SingleThreadedServerChannel<T, T> im
     }
 
     @Override
-    protected void onOpenConnection(Host peer) {
+    protected void onOpenConnection(Host peer, int connection) {
         throw new UnsupportedOperationException("I am Server, not Client");
     }
 

--- a/src/main/java/pt/unl/fct/di/novasys/channel/tcp/MultithreadedTCPChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/tcp/MultithreadedTCPChannel.java
@@ -93,7 +93,7 @@ public class MultithreadedTCPChannel<T> implements IChannel<T>, MessageListener<
     }
 
     @Override
-    public void openConnection(Host peer) {
+    public void openConnection(Host peer, int connection) {
         if (establishedOut.containsKey(peer)) return;
         pendingOut.computeIfAbsent(peer, k ->
                 Pair.of(network.createConnection(peer, attributes, this), new LinkedList<>()));

--- a/src/main/java/pt/unl/fct/di/novasys/channel/tcp/SharedTCPChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/tcp/SharedTCPChannel.java
@@ -1,0 +1,56 @@
+package pt.unl.fct.di.novasys.channel.tcp;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import pt.unl.fct.di.novasys.channel.ChannelListener;
+import pt.unl.fct.di.novasys.network.ISerializer;
+import pt.unl.fct.di.novasys.network.data.Host;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SharedTCPChannel<T> extends TCPChannel<T> {
+
+    private static final Logger logger = LogManager.getLogger(SharedTCPChannel.class);
+
+    private final Map<Host, Map<Integer, Object>> connections;
+
+    public final static String NAME = "SharedTCPChannel";
+
+    public SharedTCPChannel(ISerializer<T> serializer, ChannelListener<T> list, Properties properties) throws IOException {
+        super(serializer, list, properties);
+        connections = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    protected void onOpenConnection(Host peer, int connection) {
+        super.onOpenConnection(peer, connection);
+        addConnection(peer, connection);
+    }
+
+    @Override
+    protected void onCloseConnection(Host peer, int connection) {
+        Map<Integer, Object> openConnections = removeConnection(peer, connection);
+
+        if (openConnections == null || openConnections.isEmpty()) {
+            super.onCloseConnection(peer, connection);
+        }
+    }
+
+    /* --------------------------- Helpers --------------------------- */
+
+    private Map<Integer, Object> addConnection(Host peer, int connection) {
+        Map<Integer, Object> openConnections = connections.computeIfAbsent(peer, k -> new ConcurrentHashMap<>());
+        openConnections.put(connection, new Object());
+        return openConnections;
+    }
+
+    private Map<Integer, Object> removeConnection(Host peer, int connection) {
+        Map<Integer, Object> openConnections = connections.get(peer);
+        if (openConnections != null) {
+            openConnections.remove(connection);
+        }
+        return openConnections;
+    }
+}

--- a/src/main/java/pt/unl/fct/di/novasys/channel/tcp/TCPChannel.java
+++ b/src/main/java/pt/unl/fct/di/novasys/channel/tcp/TCPChannel.java
@@ -184,7 +184,7 @@ public class TCPChannel<T> extends SingleThreadedBiChannel<T, T> implements Attr
     }
 
     @Override
-    protected void onOpenConnection(Host peer) {
+    protected void onOpenConnection(Host peer, int connection) {
         ConnectionState<T> conState = outConnections.get(peer);
         if (conState == null) {
             logger.debug("onOpenConnection creating connection to: " + peer);


### PR DESCRIPTION
Added support for a `SharedTCPChannel` with the following changes in operation when compared with the `TCPChannel`:

1. When a `closeConnection` operation is requested the connection is only effectively closed if not other agent (e.g. a Babel protocol) is interested in the connection (verified using the connection identifier);

To allow the operation described above a new `SharedTCPChannel` was created and the `openConnection` method was changed to receive a connection identifier as parameter (the `closeConnection method ` already receives this parameter).